### PR TITLE
Fix for permission pipeline issues

### DIFF
--- a/.github/workflows/main_django-webservice.yml
+++ b/.github/workflows/main_django-webservice.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           python-version: '3.8'
 
-#       - name: Create and start virtual environment
-#         run: |
-#           python -m venv venv
-#           source venv/bin/activate
+      - name: Create and start virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
       
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -47,10 +47,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: django-app
-          path: .
-#           path: |
-#             . 
-#             !venv/
+          path: |
+            . 
+            !venv/
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main_django-webservice.yml
+++ b/.github/workflows/main_django-webservice.yml
@@ -43,13 +43,18 @@ jobs:
         run: |
           python manage.py test
       
-      - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+#       - name: Upload artifact for deployment jobs
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: django-app
+#           path: |
+#             . 
+#             !venv/
+      - name: Artifact (with permissions)
+        uses: actions/cache@v2
         with:
-          name: django-app
-          path: |
-            . 
-            !venv/
+          path: .
+          key: artifacts-${{ github.run_id }}-${{ github.run_number }}
 
   deploy:
     runs-on: ubuntu-latest
@@ -65,11 +70,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
     
-      - name: Download artifact from build job
-        uses: actions/download-artifact@v2
-        with:
-          name: django-app
-          path: .
+#       - name: Download artifact from build job
+#         uses: actions/download-artifact@v2
+#         with:
+#           name: django-app
+#           path: .
           
       - name: 'Deploy to Azure Web App'
         uses: azure/webapps-deploy@v2

--- a/.github/workflows/main_django-webservice.yml
+++ b/.github/workflows/main_django-webservice.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - main
-      - fixing-the-pipeline
+      - permission-pipeline-issues
   workflow_dispatch:
 
 jobs:
@@ -23,10 +23,10 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Create and start virtual environment
-        run: |
-          python -m venv venv
-          source venv/bin/activate
+#       - name: Create and start virtual environment
+#         run: |
+#           python -m venv venv
+#           source venv/bin/activate
       
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -47,17 +47,10 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: django-app
-          path: |
-            . 
-            !venv/
-            
-      - name: 'Deploy to Azure Web App'
-        uses: azure/webapps-deploy@v2
-        id: deploy-to-webapp
-        with:
-          app-name: 'django-webservice'
-          slot-name: 'Production'
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_15389E91C44247A6B4CFE00CAC05D1A7 }}
+          path: .
+#           path: |
+#             . 
+#             !venv/
 
   deploy:
     runs-on: ubuntu-latest

--- a/SEP6/settings.py
+++ b/SEP6/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'django-insecure-r+@yn4u7b6ql7frhptg51^2h7pf!ihid70%wz^r$1pb8k%!2t*
 DEBUG = True
 
 ALLOWED_HOSTS = [
-    'https://django-webservice.azurewebsites.net'
+    'django-webservice.azurewebsites.net'
 ]
 
 


### PR DESCRIPTION
For some goddamn reason github has permission issues when sharing artifacts between the jobs. Instead of uploading and downloading I am simply caching it for now. Link to the issue (https://github.com/actions/upload-artifact/issues/38)